### PR TITLE
Exposing the ScrollView ref with React.forwardRef

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@ import { StyleSheet, ScrollView, View, Platform } from 'react-native';
 import PropTypes from "prop-types";
 import LinearGradient from "react-native-linear-gradient"
 const defaultFadeColors = ['rgba(229, 229, 229, 0.18)', 'rgba(206, 201, 201, 0.6)', 'rgba(206, 201, 201, 0.9)'];
-export default class RNFadedScrollView extends Component {
+class RNFadedScrollView extends Component {
 
     constructor(props) {
         super(props);
@@ -127,6 +127,7 @@ export default class RNFadedScrollView extends Component {
                 {(this.state.allowStartFade && this.props.allowDivider) && this.getDivider()}
                 <ScrollView
                     {...this.props}
+                    ref={this.props.innerRef}
                     style={[styles.scrollViewStyle, this.props.style]}
                     onContentSizeChange={this.onContentSizeChange}
                     scrollEventThrottle={16}
@@ -171,3 +172,5 @@ RNFadedScrollView.defaultProps = {
     allowDivider: false,
     isRtl: false
 }
+
+export default React.forwardRef((props, ref) => <RNFadedScrollView {...props} innerRef={ref} />)


### PR DESCRIPTION
I was using your library after I found it on Medium in this article: https://medium.com/@swairaq/react-native-faded-scrollview-38d5fdf6f758

It works great for simple ScrollViews, but I needed to access the ref of the actual ScrollView. I used React.forwardRef and tested it in my application, which solved this perfectly. Thought I could make a pull request so you could include this functionality for others if you wish.

I did not mess with the props as I did not test it with TypeScript, but here is an important note:
https://reactjs.org/docs/forwarding-refs.html#note-for-component-library-maintainers
